### PR TITLE
fix: Ignore BibTeX entries without DOIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ For reference on MyST functionality and features reference the [MyST documentati
 
 - [x] May 2: Authors invited to submit full papers
 - [x] May 9: Webinar offered to authors
-- [ ] Jun 13: Deadline to submit first draft by authors
+- [x] Jun 13: Deadline to submit first draft by authors
   - Reviewers comment on papers to authors during this period.
   - Authors also respond to review comments with improvements to papers during this period.
-- [ ] Aug 15: Final author revision deadline
+- [ ] Aug 22: Final author revision deadline
   - Authors put down their pens.
+- [ ] Aug 30: Final reviewer decision deadline
+- [ ] Sept 6: Proceedings final sign-off by editors
 
 ## [General Information and Guidelines for Authors](https://github.com/scipy-conference/scipy_proceedings/blob/2025/README.md#general-information-and-guidelines-for-authors)
 

--- a/paper/myst.yml
+++ b/paper/myst.yml
@@ -46,6 +46,16 @@ project:
       severity: ignore
       keys:
         - pixi
+        - PyPI_website
+        - CUDA_install_guide
+        - conda-forge_github_io_issue_687
+        - anaconda-defaults-channel
+        - conda-recipe-cudatoolkit
+        - staged-recipes-pr-12882
+        - ucx-split-feedstock-pr-14
+        - pixi-docs
+        - pixi-pack
+        - Feickert_Reproducible_Machine_Learning
   exports:
     - id: pdf
       format: typst


### PR DESCRIPTION
* Ignore BibTeX entries without DOIs for Curvenote checks to pass on SciPy Proceedings repo.
   - c.f. https://github.com/scipy-conference/scipy_proceedings/ PR 1085
* Update proceedings timeline.
   - Delay final deadline to August 22nd.