### PR TITLE
fix: Use TOC to avoid includes as 'supporting documents'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ exports/
 
 # Editors
 .vscode/
+
+# MyST build outputs
+_build

--- a/paper/myst.yml
+++ b/paper/myst.yml
@@ -62,3 +62,6 @@ project:
       template: https://github.com/curvenote-templates/scipy.git
       article: main.md
       output: full_text.pdf
+  # Include only the document with includes to avoid having inputs shown as "supporting documents"
+  toc:
+    - file: main.md


### PR DESCRIPTION
* Manually set the TOC table to only list the main document with includes to avoid having all the other sections show up as "supporting documents".